### PR TITLE
Fix/pool deployment deposit

### DIFF
--- a/src/actions/getUpdateStatus.ts
+++ b/src/actions/getUpdateStatus.ts
@@ -51,6 +51,8 @@ export async function getUpdateOptionParams(
 			const maturityTimestamp = createExpiration(existingPosition.maturity)
 			const ttm = getTTM(maturityTimestamp)
 
+			// NOTE: if ttm is < 0, the iv = 0 and option = undefined
+			// NOTE: on either oracle failure, both values are undefined
 			const [iv, option] = await getGreeksAndIV(
 				existingPosition.market,
 				curPrice,
@@ -66,11 +68,11 @@ export async function getUpdateOptionParams(
 				strike: existingPosition.strike,
 				spotPrice: curPrice,
 				ts,
-				iv: ttm > 0 ? iv : undefined,
-				optionPrice: ttm > 0 ? option?.price : undefined,
-				delta: ttm > 0 ? option?.delta : undefined,
-				theta: ttm > 0 ? option?.theta : undefined,
-				vega: ttm > 0 ? option?.vega : undefined,
+				iv,
+				optionPrice: option?.price,
+				delta: option?.delta,
+				theta: option?.theta,
+				vega: option?.vega,
 				cycleOrders: true, // set to establish position in first cycle
 				ivOracleFailure: iv === undefined,
 				spotOracleFailure: curPrice === undefined,
@@ -116,6 +118,8 @@ async function processCallsAndPuts(
 	// CALLS
 	await Promise.all(
 		marketParams[market].callStrikes!.map(async (strike) => {
+			// NOTE: if ttm is < 0, the iv = 0 and option = undefined
+			// NOTE: on either oracle failure, both values are undefined
 			const [iv, option] = await getGreeksAndIV(
 				market,
 				spotPrice,
@@ -147,11 +151,11 @@ async function processCallsAndPuts(
 						strike,
 						spotPrice,
 						ts,
-						iv: ttm > 0 ? iv : undefined,
-						optionPrice: ttm > 0 ? option?.price : undefined,
-						delta: ttm > 0 ? option?.delta : undefined,
-						theta: ttm > 0 ? option?.theta : undefined,
-						vega: ttm > 0 ? option?.vega : undefined,
+						iv,
+						optionPrice: option?.price,
+						delta: option?.delta,
+						theta: option?.theta,
+						vega: option?.vega,
 						cycleOrders: true, // set to establish position in first cycle
 						ivOracleFailure: iv === undefined,
 						spotOracleFailure: spotPrice === undefined,
@@ -181,6 +185,8 @@ async function processCallsAndPuts(
 	// PUTS
 	await Promise.all(
 		marketParams[market].putStrikes!.map(async (strike) => {
+			// NOTE: if ttm is < 0, the iv = 0 and option = undefined
+			// NOTE: on either oracle failure, both values are undefined
 			const [iv, option] = await getGreeksAndIV(
 				market,
 				spotPrice,
@@ -205,11 +211,11 @@ async function processCallsAndPuts(
 						strike,
 						spotPrice,
 						ts,
-						iv: ttm > 0 ? iv : undefined,
-						optionPrice: ttm > 0 ? option?.price : undefined,
-						delta: ttm > 0 ? option?.delta : undefined,
-						theta: ttm > 0 ? option?.theta : undefined,
-						vega: ttm > 0 ? option?.vega : undefined,
+						iv,
+						optionPrice: option?.price,
+						delta: option?.delta,
+						theta: option?.theta,
+						vega: option?.vega,
 						cycleOrders: true, // set to establish position in first cycle
 						ivOracleFailure: iv === undefined,
 						spotOracleFailure: spotPrice === undefined,
@@ -270,7 +276,7 @@ function checkForUpdate(
 	if (ttm < 0) {
 		state.optionParams[optionIndex].spotPrice = spotPrice
 		state.optionParams[optionIndex].ts = ts
-		state.optionParams[optionIndex].iv = undefined
+		state.optionParams[optionIndex].iv = 0
 		state.optionParams[optionIndex].optionPrice = undefined
 		state.optionParams[optionIndex].delta = undefined
 		state.optionParams[optionIndex].theta = undefined

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,7 +5,6 @@
 
 import dotenv from 'dotenv'
 import { arbitrum, arbitrumGoerli } from '@premia/v3-abi/deployment'
-import { IPool__factory} from "@premia/v3-abi/typechain";
 
 dotenv.config()
 const { ENV, TESTNET_RPC_URL, MAINNET_RPC_URL, LP_PKEY, LP_ADDRESS } =

--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -22,6 +22,15 @@ export async function getGreeksAndIV(
 	if (spotPrice === undefined) {
 		return [undefined, undefined]
 	}
+	if (ttm <= 0){
+		log.info(
+			`Settling range orders for ${market}-${strike}-${
+				isCall ? 'C' : 'P'
+			} if they exist`,
+		)
+		// NOTE: we don't return an option object since we don't know the spot price at time of exp
+		return [0, undefined]
+	}
 
 	try {
 		iv = parseFloat(


### PR DESCRIPTION
If the bot is the deployer of a pool, the pool will have no liquidity and a marketPrice of 0.001. This confuses the bot and it would avoid posting a left side order because of the minOptionPrice filter.  Now this bot will know if it was the deployer and use the fair value instead.  On subsequent cycles, it will use the marketPrice (botDeployedPool is false).  

Expired options produced IV Oracle Failure warnings, but this is not an iv Oracle failure.  Adjustments were made to handle queries of expired options, so that oracle failure warnings are removed on expired options.  The bot will still attempt to settle expired options, and throw a warning if the marketParams contain an option that has expired.