### PR TITLE
error handling of validRangeWidth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@premia/range-order-bot",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Market Making Premia V3 Option Pools",
 	"author": "research@premia.finance",
 	"license": "MIT",


### PR DESCRIPTION
minOptionPrice < 0.003 can produce invalid range widths for left side range orders due to rounding and defaultSpread.  If the option price is < 0.003, after adjustments the left side will produce an Error.  This error was not previously handled with a try/catch so upon the error, we would not just skip the given pool, but the rest of the pools altogether for that market.

Error handling has been placed to deal with any unexpected errors in rangWidth calculation so that only that specific pool is effected and not the entire market.